### PR TITLE
chore(deps): duckdb 1.2.2-alpha.19

### DIFF
--- a/examples/apps/fastify-app/package.json
+++ b/examples/apps/fastify-app/package.json
@@ -27,7 +27,7 @@
     "fix-staged": "lint-staged --allow-empty"
   },
   "dependencies": {
-    "@duckdb/node-api": "1.2.2-alpha.18",
+    "@duckdb/node-api": "1.2.2-alpha.19",
     "@examples/db-sqlserver": "workspace:^",
     "@fast-csv/format": "5.0.2",
     "@fastify/autoload": "6.3.0",

--- a/examples/apps/nextjs-app/package.json
+++ b/examples/apps/nextjs-app/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@duckdb/duckdb-wasm": "1.29.1-dev132.0",
-    "@duckdb/node-api": "1.2.2-alpha.18",
+    "@duckdb/node-api": "1.2.2-alpha.19",
     "@examples/base-ui": "workspace:^",
     "@examples/db-sqlserver": "workspace:^",
     "@flowblade/core": "workspace:^",

--- a/examples/shared/duckb-openfoodfact/package.json
+++ b/examples/shared/duckb-openfoodfact/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@belgattitude/eslint-config-bases": "6.37.0",
-    "@duckdb/node-api": "1.2.2-alpha.18",
+    "@duckdb/node-api": "1.2.2-alpha.19",
     "@faker-js/faker": "9.8.0",
     "@flowblade/core": "workspace:^",
     "@flowblade/source-duckdb": "workspace:^",

--- a/packages/source-duckdb/package.json
+++ b/packages/source-duckdb/package.json
@@ -70,14 +70,14 @@
     "@flowblade/sql-tag": "workspace:^"
   },
   "peerDependencies": {
-    "@duckdb/node-api": "1.2.2-alpha.18",
+    "@duckdb/node-api": "1.2.2-alpha.19",
     "@flowblade/core": "workspace:^"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.1",
     "@belgattitude/eslint-config-bases": "6.37.0",
     "@codspeed/vitest-plugin": "4.0.1",
-    "@duckdb/node-api": "1.2.2-alpha.18",
+    "@duckdb/node-api": "1.2.2-alpha.19",
     "@edge-runtime/vm": "5.0.0",
     "@faker-js/faker": "9.8.0",
     "@flowblade/core": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1277,59 +1277,59 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@duckdb/node-api@npm:1.2.2-alpha.18":
-  version: 1.2.2-alpha.18
-  resolution: "@duckdb/node-api@npm:1.2.2-alpha.18"
+"@duckdb/node-api@npm:1.2.2-alpha.19":
+  version: 1.2.2-alpha.19
+  resolution: "@duckdb/node-api@npm:1.2.2-alpha.19"
   dependencies:
-    "@duckdb/node-bindings": "npm:1.2.2-alpha.18"
-  checksum: 10c0/c6f729dcebedf073686a933867b485bb7ef1bee48fcc03d39d6d512808e3c056f664a026091eb51b08294dbca76d6d7db59eabc0aaa74c4f8b7b0e5340776175
+    "@duckdb/node-bindings": "npm:1.2.2-alpha.19"
+  checksum: 10c0/c018b89f79b3989cc9f8822e4540737b601a69f01204aac6f6be951dae0e359316bf854a1be95aae7265622e7912a01cb0576c617162b76d6e251c813cc05efb
   languageName: node
   linkType: hard
 
-"@duckdb/node-bindings-darwin-arm64@npm:1.2.2-alpha.18":
-  version: 1.2.2-alpha.18
-  resolution: "@duckdb/node-bindings-darwin-arm64@npm:1.2.2-alpha.18"
+"@duckdb/node-bindings-darwin-arm64@npm:1.2.2-alpha.19":
+  version: 1.2.2-alpha.19
+  resolution: "@duckdb/node-bindings-darwin-arm64@npm:1.2.2-alpha.19"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@duckdb/node-bindings-darwin-x64@npm:1.2.2-alpha.18":
-  version: 1.2.2-alpha.18
-  resolution: "@duckdb/node-bindings-darwin-x64@npm:1.2.2-alpha.18"
+"@duckdb/node-bindings-darwin-x64@npm:1.2.2-alpha.19":
+  version: 1.2.2-alpha.19
+  resolution: "@duckdb/node-bindings-darwin-x64@npm:1.2.2-alpha.19"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@duckdb/node-bindings-linux-arm64@npm:1.2.2-alpha.18":
-  version: 1.2.2-alpha.18
-  resolution: "@duckdb/node-bindings-linux-arm64@npm:1.2.2-alpha.18"
+"@duckdb/node-bindings-linux-arm64@npm:1.2.2-alpha.19":
+  version: 1.2.2-alpha.19
+  resolution: "@duckdb/node-bindings-linux-arm64@npm:1.2.2-alpha.19"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@duckdb/node-bindings-linux-x64@npm:1.2.2-alpha.18":
-  version: 1.2.2-alpha.18
-  resolution: "@duckdb/node-bindings-linux-x64@npm:1.2.2-alpha.18"
+"@duckdb/node-bindings-linux-x64@npm:1.2.2-alpha.19":
+  version: 1.2.2-alpha.19
+  resolution: "@duckdb/node-bindings-linux-x64@npm:1.2.2-alpha.19"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@duckdb/node-bindings-win32-x64@npm:1.2.2-alpha.18":
-  version: 1.2.2-alpha.18
-  resolution: "@duckdb/node-bindings-win32-x64@npm:1.2.2-alpha.18"
+"@duckdb/node-bindings-win32-x64@npm:1.2.2-alpha.19":
+  version: 1.2.2-alpha.19
+  resolution: "@duckdb/node-bindings-win32-x64@npm:1.2.2-alpha.19"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@duckdb/node-bindings@npm:1.2.2-alpha.18":
-  version: 1.2.2-alpha.18
-  resolution: "@duckdb/node-bindings@npm:1.2.2-alpha.18"
+"@duckdb/node-bindings@npm:1.2.2-alpha.19":
+  version: 1.2.2-alpha.19
+  resolution: "@duckdb/node-bindings@npm:1.2.2-alpha.19"
   dependencies:
-    "@duckdb/node-bindings-darwin-arm64": "npm:1.2.2-alpha.18"
-    "@duckdb/node-bindings-darwin-x64": "npm:1.2.2-alpha.18"
-    "@duckdb/node-bindings-linux-arm64": "npm:1.2.2-alpha.18"
-    "@duckdb/node-bindings-linux-x64": "npm:1.2.2-alpha.18"
-    "@duckdb/node-bindings-win32-x64": "npm:1.2.2-alpha.18"
+    "@duckdb/node-bindings-darwin-arm64": "npm:1.2.2-alpha.19"
+    "@duckdb/node-bindings-darwin-x64": "npm:1.2.2-alpha.19"
+    "@duckdb/node-bindings-linux-arm64": "npm:1.2.2-alpha.19"
+    "@duckdb/node-bindings-linux-x64": "npm:1.2.2-alpha.19"
+    "@duckdb/node-bindings-win32-x64": "npm:1.2.2-alpha.19"
   dependenciesMeta:
     "@duckdb/node-bindings-darwin-arm64":
       optional: true
@@ -1341,7 +1341,7 @@ __metadata:
       optional: true
     "@duckdb/node-bindings-win32-x64":
       optional: true
-  checksum: 10c0/bc407b4f7c580ccd5a7a3e70ffff039269d044da34a77419b57d82b0ac7f13935a887a9022c0eb6dce2fe76d1c0c9ec17601427e2cbe4e7d9957595bbdbdb34b
+  checksum: 10c0/7f00ea4d7f67203995fae8f03dfbe6f5441ca04cc645d6d737a8505e7a7e051edb1f016d1e2e5af1c0b20fec0185d3f915b93199755b6c994efb3e01299315fb
   languageName: node
   linkType: hard
 
@@ -1761,7 +1761,7 @@ __metadata:
   resolution: "@examples/duckdb-openfoodfact@workspace:examples/shared/duckb-openfoodfact"
   dependencies:
     "@belgattitude/eslint-config-bases": "npm:6.37.0"
-    "@duckdb/node-api": "npm:1.2.2-alpha.18"
+    "@duckdb/node-api": "npm:1.2.2-alpha.19"
     "@faker-js/faker": "npm:9.8.0"
     "@flowblade/core": "workspace:^"
     "@flowblade/source-duckdb": "workspace:^"
@@ -1810,7 +1810,7 @@ __metadata:
   resolution: "@examples/fastify-app@workspace:examples/apps/fastify-app"
   dependencies:
     "@belgattitude/eslint-config-bases": "npm:6.37.0"
-    "@duckdb/node-api": "npm:1.2.2-alpha.18"
+    "@duckdb/node-api": "npm:1.2.2-alpha.19"
     "@examples/db-sqlserver": "workspace:^"
     "@fast-csv/format": "npm:5.0.2"
     "@fastify/autoload": "npm:6.3.0"
@@ -1867,7 +1867,7 @@ __metadata:
   dependencies:
     "@belgattitude/eslint-config-bases": "npm:6.37.0"
     "@duckdb/duckdb-wasm": "npm:1.29.1-dev132.0"
-    "@duckdb/node-api": "npm:1.2.2-alpha.18"
+    "@duckdb/node-api": "npm:1.2.2-alpha.19"
     "@examples/base-ui": "workspace:^"
     "@examples/db-sqlserver": "workspace:^"
     "@faker-js/faker": "npm:9.8.0"
@@ -2306,7 +2306,7 @@ __metadata:
     "@arethetypeswrong/cli": "npm:0.18.1"
     "@belgattitude/eslint-config-bases": "npm:6.37.0"
     "@codspeed/vitest-plugin": "npm:4.0.1"
-    "@duckdb/node-api": "npm:1.2.2-alpha.18"
+    "@duckdb/node-api": "npm:1.2.2-alpha.19"
     "@edge-runtime/vm": "npm:5.0.0"
     "@faker-js/faker": "npm:9.8.0"
     "@flowblade/core": "workspace:^"
@@ -2338,7 +2338,7 @@ __metadata:
     vitest: "npm:3.1.4"
     webpack: "npm:5.99.9"
   peerDependencies:
-    "@duckdb/node-api": 1.2.2-alpha.18
+    "@duckdb/node-api": 1.2.2-alpha.19
     "@flowblade/core": "workspace:^"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the `@duckdb/node-api` dependency to version 1.2.2-alpha.19 across multiple example apps and packages to ensure consistency and access to the latest improvements. No other changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->