### PR TITLE
feat: add support for custom date via duckdbType

### DIFF
--- a/.changeset/perky-crabs-act.md
+++ b/.changeset/perky-crabs-act.md
@@ -1,0 +1,18 @@
+---
+"@flowblade/sqlduck": minor
+---
+
+Support custom date when specified as meta
+
+You can now specify a custom date type when using the `duckdbType` meta.
+The create table will now use duckdb DATE type instead of VARCHAR.
+
+```typescript
+export const testFullSupportedColumnsZodSchema = z.strictObject({
+    custom_date_only_type: z.string().meta({
+        duckdbType: 'DATE',
+    }),
+});
+```
+
+See https://duckdb.org/docs/lts/sql/data_types/date

--- a/packages/sqlduck/src/table/get-table-create-from-zod.test.ts
+++ b/packages/sqlduck/src/table/get-table-create-from-zod.test.ts
@@ -1,6 +1,7 @@
 import {
   BIGINT,
   BOOLEAN,
+  DATE,
   DECIMAL,
   DOUBLE,
   type DuckDBType,
@@ -54,6 +55,7 @@ describe('getTableCreateFromZod', () => {
                 is_active BOOLEAN,
                 alt_uuid_v7 UUID NOT NULL,
                 custom_type UUID NOT NULL,
+                custom_date_only_type DATE NOT NULL,
                 js_enum ENUM('a', 'b', 'c') NOT NULL,
                 decimal_18_3 DECIMAL(18, 3) NOT NULL
                )`,
@@ -100,6 +102,7 @@ describe('getTableCreateFromZod', () => {
           ['is_active', BOOLEAN],
           ['alt_uuid_v7', UUID],
           ['custom_type', UUID],
+          ['custom_date_only_type', DATE],
           ['js_enum', ENUM(['a', 'b', 'c'])],
           ['decimal_18_3', DECIMAL(18, 3)],
         ])

--- a/packages/sqlduck/src/table/get-table-create-from-zod.ts
+++ b/packages/sqlduck/src/table/get-table-create-from-zod.ts
@@ -1,6 +1,7 @@
 import {
   BIGINT,
   BOOLEAN,
+  DATE,
   DOUBLE,
   DuckDBDecimalType,
   type DuckDBType,
@@ -62,6 +63,7 @@ const duckDbTypes = [
   ['INTEGER', INTEGER],
   ['DOUBLE', DOUBLE],
   ['FLOAT', FLOAT],
+  ['DATE', DATE],
   // to get the proper type, we just instanciate the default
   ['DECIMAL', new DuckDBDecimalType(18, 3)],
 ] as const satisfies [string, DuckDBType][];

--- a/packages/sqlduck/tests/data/test-full-supported-columns-zod-schema.ts
+++ b/packages/sqlduck/tests/data/test-full-supported-columns-zod-schema.ts
@@ -23,6 +23,9 @@ export const testFullSupportedColumnsZodSchema = z.strictObject({
   custom_type: z.string().meta({
     duckdbType: 'UUID',
   }),
+  custom_date_only_type: z.string().meta({
+    duckdbType: 'DATE',
+  }),
   js_enum: z.enum(['a', 'b', 'c']),
   decimal_18_3: z.float32().meta({
     multipleOf: 0.001,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using a custom date field type so table creation can map it to DuckDB’s native `DATE` column type.
  * Expanded the schema example to show how to define this date-only field.

* **Tests**
  * Updated table-generation expectations to verify the new `DATE` column mapping and generated SQL output.

* **Chores**
  * Added a release note entry for the upcoming minor version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->