### PR TITLE
feat: add support for iso date

### DIFF
--- a/.changeset/funny-berries-jog.md
+++ b/.changeset/funny-berries-jog.md
@@ -1,0 +1,15 @@
+---
+"@flowblade/sqlduck": minor
+---
+
+Add support for z.iso.date() and duckdb DATE type in table creation
+
+```typescript
+const useSchema = z.object({
+  name: z.string(),
+  birth_date: z.iso.date(),  // this will create a duckdb DATE column
+  first_commit_date: z.nullable(z.iso.date()),  // this will create a duckdb nullable DATE column
+});
+```
+
+Also note tha

--- a/packages/sqlduck/README_TYPES.md
+++ b/packages/sqlduck/README_TYPES.md
@@ -5,14 +5,14 @@ Supported Zod to DuckDB type mappings in `@flowblade/sqlduck`.
 ## Mappings
 
 | Zod type                   | DuckDB type                |
-| -------------------------- | -------------------------- |
+| -------------------------- |----------------------------|
 | `z.string()`               | `VARCHAR`                  |
 | `z.email()`                | `VARCHAR`                  |
 | `z.url()`                  | `VARCHAR`                  |
 | `z.cuid()`                 | `VARCHAR`                  |
 | `z.cuid2()`                | `VARCHAR`                  |
 | `z.ulid()`                 | `VARCHAR`                  |
-| `z.iso.date()`             | `VARCHAR`                  |
+| `z.iso.date()`             | `DATE`                     |
 | `z.iso.time()`             | `VARCHAR`                  |
 | `z.iso.datetime()`         | `TIMESTAMP`                |
 | `z.uuid()` / `z.uuidv7()`  | `UUID`                     |
@@ -23,6 +23,7 @@ Supported Zod to DuckDB type mappings in `@flowblade/sqlduck`.
 | `z.number()`               | inferred, default `BIGINT` |
 | `zodCodecs.dateToString`   | `TIMESTAMP`                |
 | `zodCodecs.bigintToString` | `BIGINT`                   |
+
 
 ## Numeric inference
 
@@ -62,7 +63,7 @@ const schema = z.object({
   name: z.string(), // VARCHAR NOT NULL
   email: z.email().nullable(), // VARCHAR
   score: z.float32(), // FLOAT NOT NULL
-  created_at: zodCodecs.dateToString, // TIMESTAMP NOT NULL
+  created_at: z.iso.date(), // DATE NOT NULL
   ext_id: z.uuidv7(), // UUID NOT NULL
   big_counter: z.nullable(zodCodecs.bigintToString), // BIGINT
 });

--- a/packages/sqlduck/src/converter/create-duck-column-converters.ts
+++ b/packages/sqlduck/src/converter/create-duck-column-converters.ts
@@ -51,6 +51,9 @@ export const createDuckColumnConverters = <
       case DuckDBTypeId.DECIMAL:
         conv = converter.createDecimalConverter(18, 3);
         break;
+      case DuckDBTypeId.DATE:
+        conv = converter.toDate;
+        break;
       default:
         throw new Error(
           `Unsupported duck type ${duckTypeId} / ${duckType.toString()} for column '${key}'`

--- a/packages/sqlduck/src/converter/duck-value-converter.test.ts
+++ b/packages/sqlduck/src/converter/duck-value-converter.test.ts
@@ -1,4 +1,7 @@
-import { DuckDBTimestampMillisecondsValue } from '@duckdb/node-api';
+import {
+  DuckDBDateValue,
+  DuckDBTimestampMillisecondsValue,
+} from '@duckdb/node-api';
 import { describe } from 'vitest';
 
 import { DuckValueConverter } from './duck-value-converter.ts';
@@ -68,11 +71,50 @@ describe('DuckValueConverter', () => {
       );
     });
     it('should convert an YYYY-mm-dd to a DuckDBTimestampValue', () => {
-      const dateYmd = '2023-12-28'; // new Date().toISOString()
+      const dateYmd = '2026-12-28'; // new Date().toISOString()
       expect(converter.toTimestampMs(dateYmd)).toStrictEqual(
         new DuckDBTimestampMillisecondsValue(
           BigInt(new Date(`${dateYmd}T00:00:00.000Z`).getTime())
         )
+      );
+    });
+  });
+  describe('toDate', () => {
+    it('should convert string date ymd', () => {
+      const dateStrYmd = '2026-12-28';
+      expect(converter.toDate(dateStrYmd)).toStrictEqual(
+        new DuckDBDateValue(20_815)
+      );
+    });
+
+    it('should convert iso string date (ignoring tz)', () => {
+      const isoDateStr = '2026-12-28T23:59:59.653Z';
+      expect(converter.toDate(isoDateStr)).toStrictEqual(
+        new DuckDBDateValue(20_815)
+      );
+    });
+    it('should accept a date', () => {
+      const isoDate = new Date('2026-12-28T23:59:59.653Z');
+      expect(converter.toDate(isoDate)).toStrictEqual(
+        new DuckDBDateValue(20_815)
+      );
+    });
+    it('should throw when the date is garbage', () => {
+      const garbageDate = '2026-30-30';
+      expect(() => converter.toDate(garbageDate)).toThrow(
+        '[DuckValueConverter.toDate]: Unsupported type string with value "2026-30-30"'
+      );
+    });
+    it('should return null when undefined is given', () => {
+      expect(converter.toDate(undefined)).toStrictEqual(null);
+    });
+    it('should return null when null is given', () => {
+      expect(converter.toDate(null)).toStrictEqual(null);
+    });
+    it('should throw when a boolean is given', () => {
+      // @ts-expect-error for testing
+      expect(() => converter.toDate(true)).toThrow(
+        '[DuckValueConverter.toDate]: Unsupported type boolean with value true'
       );
     });
   });

--- a/packages/sqlduck/src/converter/duck-value-converter.ts
+++ b/packages/sqlduck/src/converter/duck-value-converter.ts
@@ -1,4 +1,5 @@
 import {
+  DuckDBDateValue,
   DuckDBDecimalValue,
   DuckDBTimestampMillisecondsValue,
 } from '@duckdb/node-api';
@@ -7,6 +8,8 @@ const stringTimestampRegexp =
   /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d{3,6})?Z?$/i;
 
 const dateRegexp = /^\d{4}-\d{2}-\d{2}$/;
+
+const msInDay = 86_400_000;
 
 const createDuckValueConverterTypeError = (params: {
   method: keyof typeof DuckValueConverter.prototype;
@@ -24,6 +27,10 @@ const createDuckValueConverterTypeError = (params: {
 };
 
 export class DuckValueConverter {
+  /**
+   *
+   * @param value
+   */
   toUUID = (value: string | bigint | null | undefined): bigint | null => {
     if (typeof value === 'bigint') {
       return value;
@@ -62,10 +69,34 @@ export class DuckValueConverter {
       if (typeof value === 'bigint') {
         return new DuckDBDecimalValue(value, width, scale);
       }
-      throw new TypeError(
-        'Decimal converter require value to be a number or a bigint'
-      );
+      throw createDuckValueConverterTypeError({
+        method: 'createDecimalConverter',
+        value,
+      });
     };
+
+  toDate = (value: Date | string | null | undefined) => {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    let dateInMs: number | null = null;
+    if (typeof value === 'string' && value.length >= 10 && value.length < 30) {
+      const dateStr = value.slice(0, 10);
+      const utcDate = new Date(`${dateStr}T00:00:00Z`);
+      dateInMs = Math.floor(utcDate.getTime());
+    } else if (value instanceof Date) {
+      dateInMs = Math.floor(value.getTime());
+    }
+    if (dateInMs !== null && !Number.isNaN(dateInMs)) {
+      return new DuckDBDateValue(Math.floor(dateInMs / msInDay));
+    }
+    throw createDuckValueConverterTypeError({
+      method: 'toDate',
+      value,
+    });
+  };
+
   toBigIntString = (
     value: string | number | bigint | null | undefined
   ): string | null => {

--- a/packages/sqlduck/src/sql-duck.ts
+++ b/packages/sqlduck/src/sql-duck.ts
@@ -20,6 +20,7 @@ import { createTableFromZod } from './table/create-table-from-zod.ts';
 import type { TableCreateOptions } from './table/get-table-create-from-zod.ts';
 import type { TableSchemaZod } from './table/table-schema-zod.type.ts';
 import { rowsToColumnsChunks } from './utils/rows-to-columns-chunks.ts';
+import type { InferZodRelaxedDataSchema } from './validation/zod/index.ts';
 
 export type SqlDuckParams = {
   conn: DuckDBConnection;
@@ -48,7 +49,7 @@ export type ToTableParams<TSchema extends TableSchemaZod> = {
    * An iterable (async or sync) or generator that yields rows to be inserted.
    * Each row must match the structure defined in the `schema`.
    */
-  rowStream: RowStream<z.infer<TSchema>>;
+  rowStream: RowStream<InferZodRelaxedDataSchema<TSchema>>;
   /**
    * The number of rows to accumulate before appending them to the DuckDB table as a single data chunk.
    * Tuning this value can impact memory usage and insertion performance.
@@ -262,7 +263,9 @@ export class SqlDuck {
 
     const chunkAppendedCollector = createOnChunkAppendedCollector();
 
-    const columnStream = rowsToColumnsChunks<z.output<TSchema>>({
+    const columnStream = rowsToColumnsChunks<
+      InferZodRelaxedDataSchema<TSchema>
+    >({
       rows: rowStream,
       chunkSize: chunkSize,
       transformers: transformers,
@@ -283,7 +286,7 @@ export class SqlDuck {
         // eslint-disable-next-line unicorn/no-new-array, @typescript-eslint/no-explicit-any
         const columns = new Array<any[]>(numColumns);
         for (let i = 0; i < numColumns; i++) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-member-access
           columns[i] = dataChunk[columnKeys[i]] as any[];
         }
 

--- a/packages/sqlduck/src/table/get-table-create-from-zod.test.ts
+++ b/packages/sqlduck/src/table/get-table-create-from-zod.test.ts
@@ -56,6 +56,7 @@ describe('getTableCreateFromZod', () => {
                 alt_uuid_v7 UUID NOT NULL,
                 custom_type UUID NOT NULL,
                 custom_date_only_type DATE NOT NULL,
+                iso_date DATE NOT NULL,
                 js_enum ENUM('a', 'b', 'c') NOT NULL,
                 decimal_18_3 DECIMAL(18, 3) NOT NULL
                )`,
@@ -103,6 +104,7 @@ describe('getTableCreateFromZod', () => {
           ['alt_uuid_v7', UUID],
           ['custom_type', UUID],
           ['custom_date_only_type', DATE],
+          ['iso_date', DATE],
           ['js_enum', ENUM(['a', 'b', 'c'])],
           ['decimal_18_3', DECIMAL(18, 3)],
         ])

--- a/packages/sqlduck/src/table/get-table-create-from-zod.test.ts
+++ b/packages/sqlduck/src/table/get-table-create-from-zod.test.ts
@@ -32,6 +32,7 @@ describe('getTableCreateFromZod', () => {
             create: 'CREATE_OR_REPLACE',
           },
         });
+
         const duckdbFmtDialect = {
           dialect: duckDbDialect,
           useTabs: false,
@@ -124,7 +125,7 @@ describe('getTableCreateFromZod', () => {
           // @ts-expect-error schema cannot contain a nested object
           schema: schema,
         })
-      ).toThrowError();
+      ).toThrow();
     });
   });
 });

--- a/packages/sqlduck/src/table/get-table-create-from-zod.ts
+++ b/packages/sqlduck/src/table/get-table-create-from-zod.ts
@@ -93,7 +93,8 @@ export const getTableCreateFromZod = <TSchema extends TableSchemaZod>(
     def: {
       type: 'number' | 'integer' | 'string' | 'boolean';
       nullable: boolean | undefined;
-      format: 'date-time' | 'int64' | 'uuid' | 'cuid' | 'cuid2' | undefined;
+      format:
+        'date' | 'date-time' | 'int64' | 'uuid' | 'cuid' | 'cuid2' | undefined;
       primaryKey: boolean | undefined;
       minimum?: number;
       maximum?: number;
@@ -126,6 +127,9 @@ export const getTableCreateFromZod = <TSchema extends TableSchemaZod>(
             c.duckdbType = ENUM(def.enum);
           } else {
             switch (format) {
+              case 'date':
+                c.duckdbType = DATE;
+                break;
               case 'date-time':
                 c.duckdbType = TIMESTAMP_MS;
                 break;

--- a/packages/sqlduck/src/validation/zod/index.ts
+++ b/packages/sqlduck/src/validation/zod/index.ts
@@ -10,3 +10,4 @@ export {
 export { duckDsnZodSchema } from './duck-dsn-zod-schema.ts';
 export { duckValidatorsZod } from './duck-validators-zod.ts';
 export { ensureZodTableSchema } from './ensure-zod-table-schema.ts';
+export type { InferZodRelaxedDataSchema } from './infer-zod-relaxed-data-schema.ts';

--- a/packages/sqlduck/src/validation/zod/infer-zod-relaxed-data-schema.test.ts
+++ b/packages/sqlduck/src/validation/zod/infer-zod-relaxed-data-schema.test.ts
@@ -1,0 +1,33 @@
+import { expectTypeOf } from 'vitest';
+import * as z from 'zod';
+
+import type { InferZodRelaxedDataSchema } from './infer-zod-relaxed-data-schema.ts';
+
+describe('InferZodRelaxedDataSchema', () => {
+  it('should add string to date field', () => {
+    const _userSchema = z.strictObject({
+      id: z.string(),
+      age: z.number(),
+      createdAt: z.date(), // Native Date
+      createdAtNullable: z.nullable(z.date()), // Native Date
+      updatedAt: z.iso.date(), // Custom Codec
+    });
+
+    const record: InferZodRelaxedDataSchema<typeof _userSchema> = {
+      createdAt: new Date(),
+      createdAtNullable: new Date(),
+      age: 10,
+      updatedAt: new Date().toISOString(),
+      // updatedAt: new Date(),
+      id: 'xxx',
+    };
+
+    expectTypeOf(record).toMatchObjectType<{
+      createdAt: Date | string;
+      createdAtNullable: Date | string | null;
+      age: number;
+      updatedAt: Date | string;
+      id: string;
+    }>();
+  });
+});

--- a/packages/sqlduck/src/validation/zod/infer-zod-relaxed-data-schema.ts
+++ b/packages/sqlduck/src/validation/zod/infer-zod-relaxed-data-schema.ts
@@ -1,0 +1,29 @@
+import type * as z from 'zod';
+
+// 2. Recursive checker analyzing schema elements according to Zod v4 internal types
+type MapRelaxedZodSchemaField<T extends z.ZodTypeAny> =
+  // Identify ZodDate
+  T extends z.ZodDate
+    ? string | Date
+    : // Identify your custom ZodIsoDate codec / brand
+      T extends z.ZodISODate
+      ? string | Date
+      : // Unwrap Optional modifiers safely via Zod v4's internal '_def' footprint
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        T extends z.ZodOptional<any>
+        ? MapRelaxedZodSchemaField<T['_def']['innerType']> | undefined
+        : // Unwrap Nullable modifiers safely via Zod v4's internal '_def' footprint
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          T extends z.ZodNullable<any>
+          ? MapRelaxedZodSchemaField<T['_def']['innerType']> | null
+          : // Fallback for primitive schemas (strings, numbers, booleans, arrays)
+            z.infer<T>;
+
+/**
+ * Add string type to all Date properties so it makes it an union between
+ * Date | string
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type InferZodRelaxedDataSchema<T extends z.ZodObject<any>> = {
+  [K in keyof T['shape']]: MapRelaxedZodSchemaField<T['shape'][K]>;
+};

--- a/packages/sqlduck/tests/data/test-full-supported-columns-zod-schema.ts
+++ b/packages/sqlduck/tests/data/test-full-supported-columns-zod-schema.ts
@@ -26,13 +26,23 @@ export const testFullSupportedColumnsZodSchema = z.strictObject({
   custom_date_only_type: z.string().meta({
     duckdbType: 'DATE',
   }),
+  // iso_date: z.iso.date(),
+  iso_date: z.codec(
+    z.date(), // Input schema (Date object)
+    z.iso.date(), // Output schema (Iso date string)
+    {
+      decode: (date) => date.toISOString().split('T')[0]!,
+      encode: (isoString) => new Date(isoString),
+    }
+  ),
   js_enum: z.enum(['a', 'b', 'c']),
   decimal_18_3: z.float32().meta({
     multipleOf: 0.001,
   }),
-  /*
-  text_json: z.object({
-    name: z.string(),
-    age: z.number(),
-  }) */
 });
+
+type A = Pick<z.input<typeof testFullSupportedColumnsZodSchema>, 'iso_date'>;
+
+const a: A = {
+  iso_date: new Date(),
+};

--- a/packages/sqlduck/tests/data/test-full-supported-columns-zod-schema.ts
+++ b/packages/sqlduck/tests/data/test-full-supported-columns-zod-schema.ts
@@ -26,23 +26,9 @@ export const testFullSupportedColumnsZodSchema = z.strictObject({
   custom_date_only_type: z.string().meta({
     duckdbType: 'DATE',
   }),
-  // iso_date: z.iso.date(),
-  iso_date: z.codec(
-    z.date(), // Input schema (Date object)
-    z.iso.date(), // Output schema (Iso date string)
-    {
-      decode: (date) => date.toISOString().split('T')[0]!,
-      encode: (isoString) => new Date(isoString),
-    }
-  ),
+  iso_date: z.iso.date(),
   js_enum: z.enum(['a', 'b', 'c']),
   decimal_18_3: z.float32().meta({
     multipleOf: 0.001,
   }),
 });
-
-type A = Pick<z.input<typeof testFullSupportedColumnsZodSchema>, 'iso_date'>;
-
-const a: A = {
-  iso_date: new Date(),
-};

--- a/packages/sqlduck/tests/e2e/mssql/mssql.e2e.test.ts
+++ b/packages/sqlduck/tests/e2e/mssql/mssql.e2e.test.ts
@@ -29,11 +29,14 @@ type DB = {
     positive_bigint: string | null;
     negative_bigint: string | null;
     null_column: number | null;
+    iso_date: Date | null;
     decimal_18_3: number;
   };
 };
 
 const testDataCount = isInCi ? 2500 : 5000;
+
+const anIsoDate = new Date('2026-12-28T23:59:59.653Z');
 
 const data = Array.from({ length: testDataCount }).map((_v, idx) => {
   return {
@@ -42,6 +45,7 @@ const data = Array.from({ length: testDataCount }).map((_v, idx) => {
     decimal_18_3: Number.parseFloat(
       `${idx + 1}.${((idx + 1) % 1000).toString(10).padStart(3, '0')}`
     ),
+    iso_date: anIsoDate,
   };
 });
 
@@ -60,7 +64,8 @@ const getMigrations = (
                positive_bigint BIGINT,
                negative_bigint BIGINT,
                null_column INT,
-               decimal_18_3 DECIMAL(18,3),            
+               decimal_18_3 DECIMAL(18,3),
+               iso_date DATE,
             );`
       );
 
@@ -69,12 +74,13 @@ const getMigrations = (
         DECLARE @Data NVARCHAR(MAX); -- WARNING LIMIT TO 2GB
         SET @Data = ${JSON.stringify(data)};
 
-        INSERT INTO TestTable (id, name, decimal_18_3)
-        SELECT id, name, decimal_18_3
+        INSERT INTO TestTable (id, name, decimal_18_3, iso_date)
+        SELECT id, name, decimal_18_3, iso_date
         FROM OPENJSON(@Data) WITH (
           id INT,
           name NVARCHAR(255),
-          decimal_18_3 DECIMAL(18,3)      
+          decimal_18_3 DECIMAL(18,3),
+          iso_date DATE
         );
       `;
 
@@ -135,6 +141,7 @@ describe('MSSQL e2e tests', () => {
             't.negative_bigint',
             't.null_column',
             't.decimal_18_3',
+            't.iso_date',
           ]);
 
         const { data, error } = await mssqlDs.query(query);
@@ -147,6 +154,10 @@ describe('MSSQL e2e tests', () => {
           negative_bigint: negativeBigint.toString(10),
           null_column: null,
           decimal_18_3: 1.001,
+          // sqlserver will return the date as js date with T00:00:00.000Z
+          iso_date: new Date(
+            `${anIsoDate.toISOString().split('T')[0]}T00:00:00.000Z`
+          ),
         });
       },
       testTimeout
@@ -163,6 +174,7 @@ describe('MSSQL e2e tests', () => {
           'negative_bigint',
           'null_column',
           'decimal_18_3',
+          'iso_date',
         ]);
 
       const rowStream = mssqlDs.stream(query, {
@@ -191,6 +203,7 @@ describe('MSSQL e2e tests', () => {
         decimal_18_3: z.float32().meta({
           multipleOf: 0.001,
         }),
+        iso_date: z.nullable(z.iso.date()),
       });
 
       const { totalRows } = await sqlDuck.toTable({
@@ -214,6 +227,7 @@ describe('MSSQL e2e tests', () => {
             negative_bigint: negativeBigint.toString(10),
             positive_bigint: positiveBigint.toString(10),
             null_column: null,
+            iso_date: anIsoDate.toISOString().split('T')[0],
             decimal_18_3: `${row.id + 1}.${((row.id + 1) % 1000).toString(10).padStart(3, '0')}`,
           };
         })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `z.iso.date()` to map to DuckDB `DATE` (including nullable `DATE`) and ensure correct end-to-end round-tripping.
* **Bug Fixes**
  * Fixed an issue where date-only values were rejected as unsupported, and improved behavior for invalid date inputs.
* **Tests**
  * Expanded unit and end-to-end coverage for date conversion, schema generation, and MSSQL ingestion.
* **Documentation**
  * Updated the type-mapping docs to reflect `z.iso.date()` → DuckDB `DATE`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->